### PR TITLE
rename geojson to IST_RadlVorrangNetz_MunichWays_V20.geojson

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,4 +23,4 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: geojson
-        path: munichways.geojson
+        path: IST_RadlVorrangNetz_MunichWays_V20.geojson

--- a/create_geojson.mjs
+++ b/create_geojson.mjs
@@ -352,7 +352,7 @@ const geoJson = {
     type: "FeatureCollection",
     features,
 }
-console.log("writing output file munichways.geojson ...");
-writeFileSync("./munichways.geojson", JSON.stringify(geoJson));
+console.log("writing output file IST_RadlVorrangNetz_MunichWays_V20.geojson ...");
+writeFileSync("./IST_RadlVorrangNetz_MunichWays_V20.geojson", JSON.stringify(geoJson));
 
 console.log("done!")


### PR DESCRIPTION
Damit wir uns das umbenennen sparen können.
https://github.com/MunichWays/masterliste/wiki/GeoJSON-Datei-erstellen